### PR TITLE
Add Gradle build with logging and JUnit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ bin/
 /lib
 /sim4da.log
 /sim4da-*.log
+
+# Gradle build files
+.gradle/
+build/
+
+gradle_test.log

--- a/README.md
+++ b/README.md
@@ -73,3 +73,15 @@ By default, a “hidden” `logback.xml` on the classpath configures **DEBUG**-l
 
 - See `OneRingToRuleThemAllTest.java` for a complete token-passing simulation example.
 - Review Javadoc comments in `Node.java` and `NetworkConnection.java` for detailed API guidance.
+
+## Building and Testing
+
+This project uses **Gradle**. The `build.gradle` file is configured to compile sources in `src/` and tests in `test/`.
+
+To build the project and run the test suite:
+
+```bash
+gradle test
+```
+
+Gradle will download required dependencies on the first run. Test results are printed to the console and can also be found under `build/reports/tests/`.

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+    id 'java'
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+repositories {
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java.srcDirs = ['src']
+        resources.srcDirs = ['resources']
+    }
+    test {
+        java.srcDirs = ['test']
+        resources.srcDirs = []
+    }
+}
+
+dependencies {
+    implementation 'org.slf4j:slf4j-api:2.0.7'
+    runtimeOnly 'ch.qos.logback:logback-classic:1.4.14'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+}
+
+test {
+    useJUnitPlatform()
+}


### PR DESCRIPTION
## Summary
- add `build.gradle` with slf4j, logback and junit-jupiter dependencies
- document how to build and run tests with Gradle
- update `.gitignore` for Gradle output

## Testing
- `gradle test --no-daemon -q`

------
https://chatgpt.com/codex/tasks/task_e_6862faa13d108326902670929737b909