### PR TITLE
Enable application plugin and add DSM demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ By default, a “hidden” `logback.xml` on the classpath configures **DEBUG**-l
 2. Define desired log levels, appenders, and formats.
 3. The simulator will automatically pick up your configuration instead of the default.
 
+## Running the Demo
+
+Start the DSM inconsistency demo with:
+
+```
+./gradlew run --args="CP"
+```
+
 ## Further Reading
 
 - See `OneRingToRuleThemAllTest.java` for a complete token-passing simulation example.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,10 @@
 plugins {
     id 'java'
+    id 'application'
+}
+
+application {
+    mainClass = 'org.oxoo2a.sim4da.demo.DSMInconsistencyDemo'
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,0 @@
-org.gradle.java.home=C:\\Users\\User\\.jdks\\openjdk-24.0.1

--- a/src/org/oxoo2a/sim4da/demo/DSMInconsistencyDemo.java
+++ b/src/org/oxoo2a/sim4da/demo/DSMInconsistencyDemo.java
@@ -1,0 +1,51 @@
+package org.oxoo2a.sim4da.demo;
+
+import org.oxoo2a.sim4da.NetworkConnection;
+import org.oxoo2a.sim4da.Simulator;
+import org.oxoo2a.sim4da.dsm.*;
+
+/**
+ * Simple demo showing how different DSM strategies affect consistency.
+ */
+public class DSMInconsistencyDemo {
+    public static void main(String[] args) {
+        String mode = args.length > 0 ? args[0] : "CP";
+
+        Simulator sim = Simulator.getInstance();
+        NetworkConnection nc1 = new NetworkConnection("n1");
+        NetworkConnection nc2 = new NetworkConnection("n2");
+
+        DistributedSharedMemory dsm1;
+        DistributedSharedMemory dsm2;
+        switch (mode) {
+            case "AP" -> {
+                dsm1 = new AP_DSM(nc1);
+                dsm2 = new AP_DSM(nc2);
+            }
+            case "CA" -> {
+                dsm1 = new CA_DSM();
+                dsm2 = new CA_DSM();
+            }
+            default -> {
+                dsm1 = new CP_DSM(nc1);
+                dsm2 = new CP_DSM(nc2);
+            }
+        }
+
+        // Engage dummy node threads so the simulator can run
+        nc1.engage(() -> {});
+        nc2.engage(() -> {});
+
+        sim.simulate(1);
+
+        // Node1 writes a value which node2 should eventually see
+        dsm1.write("key", "value");
+        try {
+            Thread.sleep(200);
+        } catch (InterruptedException ignored) {}
+
+        System.out.println("Node2 reads: " + dsm2.read("key"));
+
+        sim.shutdown();
+    }
+}


### PR DESCRIPTION
## Summary
- enable Gradle application plugin and set main class
- add DSMInconsistencyDemo example
- document how to run the demo via `./gradlew run --args="CP"`
- clean up invalid `gradle.properties`

## Testing
- `./gradlew build`
- `./gradlew run --args="CP"`
- `./gradlew run`


------
https://chatgpt.com/codex/tasks/task_e_6869339178f883269d449e0fcac05360