### PR TITLE
Enhance DSM demo with distributed consistency checks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64
+org.gradle.java.home=C:\\Users\\User\\.jdks\\openjdk-24.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.java.home=C:\\Users\\User\\.jdks\\openjdk-24.0.1
+org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64

--- a/src/org/oxoo2a/sim4da/demo/DSMInconsistencyDemo.java
+++ b/src/org/oxoo2a/sim4da/demo/DSMInconsistencyDemo.java
@@ -19,7 +19,26 @@ import java.util.Map;
 public class DSMInconsistencyDemo {
 
     /** Number of counter nodes created for the demonstration. */
-    private static final int NODE_COUNT = 3;
+    private static final int NODE_COUNT = 5;
+
+    /** Key used by all nodes when writing to the shared counter. */
+    private static final String SHARED_KEY = "shared_counter";
+
+    /** All counter keys (n0..nX plus shared counter). */
+    private static final String[] ALL_KEYS = new String[NODE_COUNT + 1];
+
+    static {
+        for (int i = 0; i < NODE_COUNT; i++) {
+            ALL_KEYS[i] = "n" + i;
+        }
+        ALL_KEYS[NODE_COUNT] = SHARED_KEY;
+    }
+
+    /** ANSI color codes for console output. */
+    private static final String RED = "\u001B[31m";
+    private static final String YELLOW = "\u001B[33m";
+    private static final String GREEN = "\u001B[32m";
+    private static final String RESET = "\u001B[0m";
 
     /**
      * Counter node using a DSM instance to share its counter value.
@@ -29,65 +48,84 @@ public class DSMInconsistencyDemo {
         private final DistributedSharedMemory dsm;
         private final NetworkConnection nc;
 
-        CounterAgent(int id, DistributedSharedMemory dsm, NetworkConnection nc) {
+        private final boolean writeOwn;
+        private final boolean writeShared;
+
+        private int local = 0;
+
+        private final Map<String, Integer> lastSeen = new HashMap<>();
+        private int rollbacks = 0;
+        private int missing = 0;
+        private int consistent = 0;
+
+        CounterAgent(int id, DistributedSharedMemory dsm, NetworkConnection nc,
+                     boolean writeOwn, boolean writeShared) {
             this.id = id;
             this.dsm = dsm;
             this.nc = nc;
+            this.writeOwn = writeOwn;
+            this.writeShared = writeShared;
+            for (String key : ALL_KEYS) {
+                lastSeen.put(key, -1);
+            }
             this.nc.engage(this::run);
         }
 
+        Metrics getMetrics() {
+            return new Metrics(rollbacks, missing, consistent);
+        }
+
         private void run() {
-            int value = 0;
-            for (int i = 0; i < 20; i++) {
-                value++;
-                dsm.write(key(), Integer.toString(value));
+            while (!Thread.currentThread().isInterrupted()) {
+                if (writeOwn) {
+                    local++;
+                    dsm.write(key(), Integer.toString(local));
+                }
+
+                if (writeShared) {
+                    String curStr = dsm.read(SHARED_KEY);
+                    int cur = curStr == null ? 0 : Integer.parseInt(curStr);
+                    dsm.write(SHARED_KEY, Integer.toString(cur + 1));
+                }
+
+                for (String other : ALL_KEYS) {
+                    String valStr = dsm.read(other);
+                    int val = valStr == null ? -1 : Integer.parseInt(valStr);
+                    int last = lastSeen.getOrDefault(other, -1);
+                    if (last != -1 && val != -1) {
+                        if (val < last) {
+                            rollbacks++;
+                            System.out.println(RED + "[" + id() + "] Rollback for " + other + ": " + last + " -> " + val + RESET);
+                        } else if (val > last + 1) {
+                            missing++;
+                            System.out.println(YELLOW + "[" + id() + "] Missing update for " + other + ": jumped from " + last + " to " + val + RESET);
+                        } else {
+                            consistent++;
+                            System.out.println(GREEN + "[" + id() + "] " + other + "=" + val + RESET);
+                        }
+                    }
+                    lastSeen.put(other, val);
+                }
+
                 try {
-                    Thread.sleep(50);
-                } catch (InterruptedException ignored) {}
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    break;
+                }
             }
         }
 
         private String key() {
             return "n" + id;
         }
-    }
 
-    /**
-     * Monitor node that reads all counters and prints anomalies.
-     */
-    static class MonitorAgent {
-        private final DistributedSharedMemory dsm;
-        private final NetworkConnection nc;
-        private final Map<String, Integer> lastSeen = new HashMap<>();
-
-        MonitorAgent(DistributedSharedMemory dsm, NetworkConnection nc) {
-            this.dsm = dsm;
-            this.nc = nc;
-            this.nc.engage(this::run);
-        }
-
-        private void run() {
-            for (int i = 0; i < 40; i++) {
-                for (int id = 0; id < NODE_COUNT; id++) {
-                    String key = "n" + id;
-                    String val = dsm.read(key);
-                    if (val == null) continue;
-                    int current = Integer.parseInt(val);
-                    Integer last = lastSeen.get(key);
-                    if (last != null && current < last) {
-                        System.out.printf("[Monitor] Rollback for %s: %d -> %d%n", key, last, current);
-                    } else if (last != null && current > last + 1) {
-                        System.out.printf("[Monitor] Missing updates for %s: jumped from %d to %d%n", key, last, current);
-                    }
-                    lastSeen.put(key, current);
-                }
-                System.out.println("[Monitor] Current view: " + lastSeen);
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException ignored) {}
-            }
+        private String id() {
+            return "n" + id;
         }
     }
+
+    private record Metrics(int rollbacks, int missing, int consistent) {}
+
 
     /**
      * Creates the correct DSM instance for the given variant string.
@@ -112,14 +150,19 @@ public class DSMInconsistencyDemo {
         for (int i = 0; i < NODE_COUNT; i++) {
             NetworkConnection nc = new NetworkConnection("n" + i);
             DistributedSharedMemory dsm = createDSM(variant, nc);
-            agents[i] = new CounterAgent(i, dsm, nc);
+            boolean writeOwn = i >= 2;           // nodes 2..4 write their own counters
+            boolean writeShared = i != 1;        // node 1 is read-only
+            agents[i] = new CounterAgent(i, dsm, nc, writeOwn, writeShared);
         }
 
-        NetworkConnection monitorNc = new NetworkConnection("monitor");
-        DistributedSharedMemory monitorDsm = createDSM(variant, monitorNc);
-        new MonitorAgent(monitorDsm, monitorNc);
-
         sim.simulate(5);
+
+        for (int i = 0; i < NODE_COUNT; i++) {
+            Metrics m = agents[i].getMetrics();
+            System.out.printf("Node n%d -> rollbacks:%d missing:%d consistent:%d%n",
+                    i, m.rollbacks, m.missing, m.consistent);
+        }
+
         sim.shutdown();
     }
 }


### PR DESCRIPTION
## Summary
- set Java home path for Gradle
- overhaul `DSMInconsistencyDemo`
  - introduce shared counter and color constants
  - let each node read all counters and detect rollbacks or missing updates
  - vary node access patterns (writer/reader)
  - gather per-node metrics and output them at the end

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_686989ecc09c8326b9eb575b1d68bb52