### PR TITLE
Add DSM inconsistency demo

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.java.home=C:\\Users\\User\\.jdks\\openjdk-24.0.1
+

--- a/src/org/oxoo2a/sim4da/demo/CounterAgent.java
+++ b/src/org/oxoo2a/sim4da/demo/CounterAgent.java
@@ -1,0 +1,59 @@
+package org.oxoo2a.sim4da.demo;
+
+import org.oxoo2a.sim4da.NetworkConnection;
+import org.oxoo2a.sim4da.Simulator;
+import org.oxoo2a.sim4da.dsm.DistributedSharedMemory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Simple agent that increments a counter in the DSM and
+ * checks counters of all peers for anomalies.
+ */
+public class CounterAgent {
+    private final NetworkConnection nc;
+    private final DistributedSharedMemory dsm;
+    private final String[] peers;
+    private final Map<String,Integer> last = new HashMap<>();
+    private final String myKey;
+
+    public CounterAgent(String name,
+                        Function<NetworkConnection, DistributedSharedMemory> factory,
+                        String[] peerNames) {
+        this.nc = new NetworkConnection(name);
+        this.dsm = factory.apply(nc);
+        this.peers = peerNames;
+        this.myKey = "counter-" + name;
+        nc.engage(this::run);
+    }
+
+    private void run() {
+        int value = 0;
+        Simulator sim = Simulator.getInstance();
+        while (sim.isSimulating()) {
+            value++;
+            dsm.write(myKey, String.valueOf(value));
+            for (String p : peers) {
+                String key = "counter-" + p;
+                String vStr = dsm.read(key);
+                if (vStr != null) {
+                    int v = Integer.parseInt(vStr);
+                    Integer prev = last.get(p);
+                    if (prev != null && v < prev) {
+                        System.out.printf("[%s] Anomaly: %s decreased from %d to %d%n",
+                                nc.NodeName(), p, prev, v);
+                    }
+                    last.put(p, v);
+                }
+            }
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+    }
+}

--- a/test/org/oxoo2a/sim4da/DSMInconsistencyDemoTest.java
+++ b/test/org/oxoo2a/sim4da/DSMInconsistencyDemoTest.java
@@ -1,0 +1,41 @@
+package org.oxoo2a.sim4da;
+
+import org.junit.jupiter.api.Test;
+import org.oxoo2a.sim4da.demo.CounterAgent;
+import org.oxoo2a.sim4da.dsm.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Demonstrates a simple counter application using different DSM implementations.
+ * Each agent updates its own counter and checks all others for inconsistencies.
+ * Anomalies are printed to stdout.
+ */
+public class DSMInconsistencyDemoTest {
+
+    private void runDemo(Function<NetworkConnection, DistributedSharedMemory> factory) {
+        final int nodes = 3;
+        Simulator sim = Simulator.getInstance();
+        String[] names = new String[nodes];
+        for (int i = 0; i < nodes; i++) {
+            names[i] = String.valueOf(i);
+        }
+        List<CounterAgent> agents = new ArrayList<>();
+        for (String n : names) {
+            agents.add(new CounterAgent(n, factory, names));
+        }
+        sim.simulate(2);
+        sim.shutdown();
+    }
+
+    @Test
+    void demoAP() { runDemo(AP_DSM::new); }
+
+    @Test
+    void demoCP() { runDemo(CP_DSM::new); }
+
+    @Test
+    void demoCA() { runDemo(nc -> new CA_DSM()); }
+}


### PR DESCRIPTION
## Summary
- create `CounterAgent` example for DSM
- demonstrate inconsistent behaviour of AP, CP and CA DSMs in new test
- clear out `gradle.properties` to use default JDK

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68699ba5e9e083268e8cedb7bbc64cfd