### PR TITLE
Add distributed counter demo with DSM logging

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.java.home=C:\\Users\\User\\.jdks\\openjdk-24.0.1
+org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64

--- a/src/org/oxoo2a/app/CSVLogger.java
+++ b/src/org/oxoo2a/app/CSVLogger.java
@@ -1,0 +1,35 @@
+package org.oxoo2a.app;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * Utility for synchronized CSV logging of observation entries.
+ */
+public class CSVLogger {
+    private static PrintWriter writer;
+
+    /** Initialize the logger with given file path. */
+    public static void init(String path) throws IOException {
+        writer = new PrintWriter(new FileWriter(path));
+        writer.println("tick,observer,observed,value,type,prev");
+    }
+
+    /** Log an entry to the CSV file. */
+    public static synchronized void log(int tick, String observer, String observed,
+                                        String value, String type, Integer prev) {
+        if (writer == null) return;
+        writer.printf("%d,%s,%s,%s,%s,%s%n", tick, observer, observed,
+                value == null ? "" : value, type,
+                prev == null ? "" : prev.toString());
+    }
+
+    /** Close the underlying writer. */
+    public static void close() {
+        if (writer != null) {
+            writer.flush();
+            writer.close();
+        }
+    }
+}

--- a/src/org/oxoo2a/app/CounterAgent.java
+++ b/src/org/oxoo2a/app/CounterAgent.java
@@ -1,0 +1,70 @@
+package org.oxoo2a.app;
+
+import org.oxoo2a.sim4da.NetworkConnection;
+import org.oxoo2a.sim4da.dsm.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * Simulation node maintaining a local counter and interacting with a
+ * distributed shared memory implementation.
+ */
+public class CounterAgent {
+    private final NetworkConnection nc;
+    private final DistributedSharedMemory dsm;
+    private final List<String> allNodes;
+    private final int ticks;
+    private final Random rnd = new Random();
+    private final Map<String,Integer> lastSeen = new HashMap<>();
+    private int counter = 0;
+
+    public CounterAgent(String name, String dsmVariant, List<String> allNodes, int ticks) {
+        this.nc = new NetworkConnection(name);
+        this.dsm = createDSM(dsmVariant, nc);
+        this.allNodes = allNodes;
+        this.ticks = ticks;
+    }
+
+    public void engage() {
+        nc.engage(this::run);
+    }
+
+    private void run() {
+        for (int t=0; t<ticks; t++) {
+            counter++;
+            dsm.write(nc.NodeName(), Integer.toString(counter));
+
+            for (String other : allNodes) {
+                String val = dsm.read(other);
+                Integer prev = lastSeen.get(other);
+                String type = "ok";
+                if (prev != null && val != null) {
+                    int v = Integer.parseInt(val);
+                    if (v < prev) type = "backjump";
+                    else if (v == prev) type = "missing_update";
+                }
+                CSVLogger.log(t, nc.NodeName(), other, val, type, prev);
+                if (val != null) lastSeen.put(other, Integer.parseInt(val));
+            }
+            try {
+                Thread.sleep(rnd.nextInt(5)+1); // small random delay
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+    }
+
+    public void join() { nc.join(); }
+
+    private static DistributedSharedMemory createDSM(String variant, NetworkConnection nc) {
+        return switch (variant.toUpperCase()) {
+            case "AP" -> new AP_DSM(nc);
+            case "CP" -> new CP_DSM(nc);
+            default -> new CA_DSM();
+        };
+    }
+}

--- a/src/org/oxoo2a/app/DSMSimulation.java
+++ b/src/org/oxoo2a/app/DSMSimulation.java
@@ -1,0 +1,35 @@
+package org.oxoo2a.app;
+
+import org.oxoo2a.sim4da.Simulator;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Entry point for running the counter/DSM simulation.
+ */
+public class DSMSimulation {
+    public static void main(String[] args) throws IOException {
+        String variant = args.length > 0 ? args[0] : "CA";
+        int nodes = args.length > 1 ? Integer.parseInt(args[1]) : 3;
+        int ticks = args.length > 2 ? Integer.parseInt(args[2]) : 200;
+
+        CSVLogger.init("dsm_log.csv");
+
+        List<String> names = new ArrayList<>();
+        List<CounterAgent> agents = new ArrayList<>();
+        for (int i=0;i<nodes;i++) {
+            names.add("n"+i);
+        }
+        for (String n : names) {
+            CounterAgent c = new CounterAgent(n, variant, names, ticks);
+            c.engage();
+            agents.add(c);
+        }
+
+        Simulator.getInstance().simulate();
+        Simulator.getInstance().shutdown();
+        CSVLogger.close();
+    }
+}

--- a/visualize.py
+++ b/visualize.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+import sys
+
+def main(path="dsm_log.csv"):
+    df = pd.read_csv(path)
+    nodes = sorted(set(df['observer']))
+    fig, axes = plt.subplots(len(nodes), 1, figsize=(8, 4*len(nodes)), sharex=True)
+    if len(nodes) == 1:
+        axes = [axes]
+    for ax, obs in zip(axes, nodes):
+        subset = df[df['observer'] == obs]
+        for target in sorted(set(subset['observed'])):
+            tdata = subset[subset['observed'] == target]
+            ax.plot(tdata['tick'], tdata['value'], label=f"{obs}->{target}")
+            bj = tdata[tdata['type'] == 'backjump']
+            ax.scatter(bj['tick'], bj['value'], color='red', marker='x', label='backjump')
+            mu = tdata[tdata['type'] == 'missing_update']
+            ax.scatter(mu['tick'], mu['value'], color='orange', marker='o', label='missing_update')
+        ax.set_title(f"Observations by {obs}")
+        ax.set_ylabel("value")
+        ax.legend()
+    axes[-1].set_xlabel("tick")
+    plt.tight_layout()
+    plt.show()
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else "dsm_log.csv")


### PR DESCRIPTION
## Summary
- update `gradle.properties` to use the JDK available in the container
- implement a small distributed counter simulation using the DSM API
- add `CSVLogger` helper for logging observations
- provide a `visualize.py` script to plot the log results

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68699e85b430832698ae1ce0d632bf16