### PR TITLE
Implement DSM experiment runner

### DIFF
--- a/src/org/oxoo2a/sim4da/Network.java
+++ b/src/org/oxoo2a/sim4da/Network.java
@@ -7,6 +7,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListSet;
 
 public class Network {
 
@@ -16,6 +20,8 @@ public class Network {
     private record Node ( NetworkConnection nc, NodeProxy np ) {}
     private final Map<String,Node> nodes = new HashMap<>();
     private final Logger logger = LoggerFactory.getLogger(Network.class);
+    private final ConcurrentMap<String, Integer> delays = new ConcurrentHashMap<>();
+    private final Set<String> partitions = new ConcurrentSkipListSet();
     private static Network instance = null;
     public static Network getInstance() {
         if (instance == null) {
@@ -51,16 +57,20 @@ public class Network {
             logger.error("Attempt to send message to non-existent node " + receiver_name);
             throw new UnknownNodeException(receiver_name);
         }
+        if (isPartitioned(sender.NodeName()) || isPartitioned(receiver_name)) return;
         Message copy = message.copy();
         copy.setSender(sender.NodeName());
         NodeProxy receiver = nodes.get(receiver_name).np;
-        receiver.deliver(copy, sender);
+        deliverWithDelay(receiver, copy, sender, getDelay(receiver_name));
     }
 
     public void send ( Message message, NetworkConnection sender ) {
         for (Node n : nodes.values()) {
             if (n.nc != sender) {
-                n.np.deliver(message, sender);
+                if (isPartitioned(sender.NodeName()) || isPartitioned(n.nc.NodeName())) continue;
+                Message copy = message.copy();
+                copy.setSender(sender.NodeName());
+                deliverWithDelay(n.np, copy, sender, getDelay(n.nc.NodeName()));
             }
         }
     }
@@ -69,6 +79,35 @@ public class Network {
         Node n = nodes.get(receiver.NodeName());
         Message m = n.np.receive();
         return m;
+    }
+
+    private boolean isPartitioned(String node) {
+        return partitions.contains(node);
+    }
+
+    private int getDelay(String node) {
+        return delays.getOrDefault(node, 0);
+    }
+
+    private void deliverWithDelay(NodeProxy receiver, Message msg, NetworkConnection sender, int delay) {
+        if (delay <= 0) {
+            receiver.deliver(msg, sender);
+        } else {
+            new Thread(() -> {
+                try { Thread.sleep(delay); } catch (InterruptedException ignored) {}
+                receiver.deliver(msg, sender);
+            }).start();
+        }
+    }
+
+    public void setNodeDelay(String node, int delayMs) { delays.put(node, delayMs); }
+    public void clearNodeDelay(String node) { delays.remove(node); }
+    public void partitionNode(String node) { partitions.add(node); }
+    public void reconnectNode(String node) { partitions.remove(node); }
+    public void reset() {
+        nodes.clear();
+        delays.clear();
+        partitions.clear();
     }
 
     public void shutdown() {

--- a/src/org/oxoo2a/sim4da/Simulator.java
+++ b/src/org/oxoo2a/sim4da/Simulator.java
@@ -26,6 +26,10 @@ public class Simulator {
         return instance;
     }
 
+    public static void reset() {
+        instance = null;
+    }
+
     public void simulate ( long duration_in_seconds ) {
         simulating = true;
         startSignal.countDown();

--- a/src/org/oxoo2a/sim4da/demo/DSMExperiments.java
+++ b/src/org/oxoo2a/sim4da/demo/DSMExperiments.java
@@ -1,0 +1,181 @@
+package org.oxoo2a.sim4da.demo;
+
+import org.oxoo2a.sim4da.Network;
+import org.oxoo2a.sim4da.NetworkConnection;
+import org.oxoo2a.sim4da.Simulator;
+import org.oxoo2a.sim4da.dsm.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Runs systematic experiments for the three DSM variants (AP, CP, CA)
+ * under different network conditions. Results of each run are printed
+ * to stdout.
+ */
+public class DSMExperiments {
+
+    private static final int NODE_COUNT = 5;
+    private static final String SHARED_KEY = "shared_counter";
+
+    /** Simple container for aggregated statistics of an agent. */
+    private record Result(int rollbacks, int missing, int ok) {}
+
+    /**
+     * Roles used for the counter agents. Matches DSMInconsistencyDemo.
+     */
+    private enum Role { WRITE_ONLY, READ_ONLY, READ_WRITE }
+
+    /**
+     * Counter agent identical to the one used in DSMInconsistencyDemo
+     * but packaged for reuse.
+     */
+    private static class CounterAgent {
+        private final int id;
+        private final DistributedSharedMemory dsm;
+        private final NetworkConnection nc;
+        private final Role role;
+        private final String[] allKeys;
+        private final Map<String,Integer> lastSeen = new HashMap<>();
+
+        int rollbackCount = 0;
+        int missingUpdateCount = 0;
+        int okCount = 0;
+
+        CounterAgent(int id, DistributedSharedMemory dsm, NetworkConnection nc,
+                     Role role, String[] allKeys) {
+            this.id = id;
+            this.dsm = dsm;
+            this.nc = nc;
+            this.role = role;
+            this.allKeys = allKeys;
+            for (String k : allKeys) {
+                lastSeen.put(k, -1);
+            }
+            this.nc.engage(this::run);
+        }
+
+        private void run() {
+            int value = 0;
+            int sharedValue = 0;
+            for (int step = 0; step < 40; step++) {
+                if (role != Role.READ_ONLY) {
+                    if (role != Role.WRITE_ONLY) {
+                        value++;
+                        dsm.write(key(), Integer.toString(value));
+                    }
+
+                    if (role == Role.WRITE_ONLY) {
+                        sharedValue++;
+                        dsm.write(SHARED_KEY, Integer.toString(sharedValue));
+                    } else {
+                        String s = dsm.read(SHARED_KEY);
+                        int sv = s == null ? 0 : Integer.parseInt(s);
+                        dsm.write(SHARED_KEY, Integer.toString(sv + 1));
+                    }
+                }
+
+                if (role != Role.WRITE_ONLY) {
+                    for (String other : allKeys) {
+                        String valStr = dsm.read(other);
+                        if (valStr == null) continue;
+                        int current = Integer.parseInt(valStr);
+                        int last = lastSeen.getOrDefault(other, -1);
+                        if (last >= 0) {
+                            if (current < last) {
+                                rollbackCount++;
+                            } else if (current > last + 1) {
+                                missingUpdateCount++;
+                            } else {
+                                okCount++;
+                            }
+                        }
+                        lastSeen.put(other, current);
+                    }
+                }
+
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ignored) {
+                    break;
+                }
+            }
+        }
+
+        private String key() { return "n" + id; }
+    }
+
+    private static DistributedSharedMemory createDSM(String variant, NetworkConnection nc) {
+        return switch (variant) {
+            case "AP" -> new AP_DSM(nc);
+            case "CP" -> new CP_DSM(nc);
+            default -> new CA_DSM();
+        };
+    }
+
+    private static Result runOnce(String variant, boolean withDelay, boolean withPartition) {
+        Network net = Network.getInstance();
+        net.reset();
+        if (withDelay) {
+            net.setNodeDelay("n2", 300);
+            net.setNodeDelay("n3", 300);
+        }
+        if (withPartition) {
+            net.partitionNode("n2");
+            net.partitionNode("n3");
+        }
+
+        Simulator sim = Simulator.getInstance();
+
+        CounterAgent[] agents = new CounterAgent[NODE_COUNT];
+        String[] keys = new String[NODE_COUNT + 1];
+        for (int i = 0; i < NODE_COUNT; i++) {
+            keys[i] = "n" + i;
+        }
+        keys[NODE_COUNT] = SHARED_KEY;
+
+        for (int i = 0; i < NODE_COUNT; i++) {
+            NetworkConnection nc = new NetworkConnection("n" + i);
+            DistributedSharedMemory dsm = createDSM(variant, nc);
+            Role role;
+            if (i == 0) role = Role.WRITE_ONLY;
+            else if (i == 1) role = Role.READ_ONLY;
+            else role = Role.READ_WRITE;
+            agents[i] = new CounterAgent(i, dsm, nc, role, keys);
+        }
+
+        sim.simulate(5);
+
+        int totalRollbacks = java.util.Arrays.stream(agents).mapToInt(a -> a.rollbackCount).sum();
+        int totalMissing = java.util.Arrays.stream(agents).mapToInt(a -> a.missingUpdateCount).sum();
+        int totalOk = java.util.Arrays.stream(agents).mapToInt(a -> a.okCount).sum();
+
+        sim.shutdown();
+        Simulator.reset();
+        net.reset();
+
+        return new Result(totalRollbacks, totalMissing, totalOk);
+    }
+
+    private static void runVariant(String variant) {
+        Result normal = runOnce(variant, false, false);
+        System.out.printf("| %s | normal | %d / %d / %d |%n", variant, normal.rollbacks, normal.missing, normal.ok);
+
+        Result delay = runOnce(variant, true, false);
+        System.out.printf("| %s | delay | %d / %d / %d |%n", variant, delay.rollbacks, delay.missing, delay.ok);
+
+        Result partition = runOnce(variant, false, true);
+        System.out.printf("| %s | partition n2+n3 | %d / %d / %d |%n", variant, partition.rollbacks, partition.missing, partition.ok);
+    }
+
+    public static void runAP() { runVariant("AP"); }
+    public static void runCP() { runVariant("CP"); }
+    public static void runCA() { runVariant("CA"); }
+
+    public static void main(String[] args) {
+        runAP();
+        runCP();
+        runCA();
+    }
+}
+


### PR DESCRIPTION
## Summary
- extend `Network` with delay and partition mechanics
- allow resetting `Simulator`
- add `DSMExperiments` to run AP/CP/CA scenarios with optional delay or partition

## Testing
- `./gradlew test`
- *(failed to run DSMExperiments due to missing runtime dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6869a7dc6b7083268d1e5cfcd0397bc5